### PR TITLE
"tap-parser" should be in package.json's "dependencies"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,9 @@
 {
 	"name": "chutney",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"JSONStream": {
-			"version": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.0.tgz",
-			"integrity": "sha1-aAq5rGVyqKGiB+CzhyHbHHeyFeU=",
-			"dev": true,
-			"requires": {
-				"jsonparse": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz",
-				"through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-			}
-		},
 		"acorn": {
 			"version": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
 			"integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ=",
@@ -63,11 +54,18 @@
 			}
 		},
 		"argparse": {
-			"version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
 			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-			"dev": true,
 			"requires": {
-				"sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+				"sprintf-js": "1.0.3"
+			},
+			"dependencies": {
+				"sprintf-js": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+				}
 			}
 		},
 		"array-filter": {
@@ -1079,9 +1077,9 @@
 			"integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
 			"dev": true,
 			"requires": {
-				"JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.0.tgz",
 				"combine-source-map": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
 				"defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+				"JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.0.tgz",
 				"through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 				"umd": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
 			}
@@ -1107,7 +1105,6 @@
 			"integrity": "sha1-CJo0Y69Y0OSNjNQHCz90ZU1avKk=",
 			"dev": true,
 			"requires": {
-				"JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.0.tgz",
 				"assert": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
 				"browser-pack": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
 				"browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
@@ -1129,6 +1126,7 @@
 				"https-browserify": "1.0.0",
 				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 				"insert-module-globals": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
+				"JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.0.tgz",
 				"labeled-stream-splicer": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
 				"module-deps": "https://registry.npmjs.org/module-deps/-/module-deps-4.0.8.tgz",
 				"os-browserify": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
@@ -1671,9 +1669,9 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"esprima": {
-			"version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-			"dev": true
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
 		},
 		"esutils": {
 			"version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -1686,9 +1684,9 @@
 			"dev": true
 		},
 		"events-to-array": {
-			"version": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.0.2.tgz",
-			"integrity": "sha1-s0hEZVNP5P9m+90ag7d3cTukBKo=",
-			"dev": true
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
+			"integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y="
 		},
 		"evp_bytestokey": {
 			"version": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
@@ -1913,10 +1911,10 @@
 			"integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
 			"dev": true,
 			"requires": {
-				"JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.0.tgz",
 				"combine-source-map": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
 				"concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
 				"is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+				"JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.0.tgz",
 				"lexical-scope": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
 				"process": "https://registry.npmjs.org/process/-/process-0.11.9.tgz",
 				"through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
@@ -1997,12 +1995,12 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-			"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-			"dev": true,
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
 			"requires": {
-				"argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-				"esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+				"argparse": "1.0.9",
+				"esprima": "4.0.0"
 			}
 		},
 		"jsbn": {
@@ -2039,6 +2037,15 @@
 		"jsonpointer": {
 			"version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
 			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+		},
+		"JSONStream": {
+			"version": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.0.tgz",
+			"integrity": "sha1-aAq5rGVyqKGiB+CzhyHbHHeyFeU=",
+			"dev": true,
+			"requires": {
+				"jsonparse": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.0.tgz",
+				"through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+			}
 		},
 		"jsprim": {
 			"version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
@@ -2627,7 +2634,6 @@
 			"integrity": "sha1-Vf1wYjOZcGwyiL73pgn/HowO0rs=",
 			"dev": true,
 			"requires": {
-				"JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.0.tgz",
 				"browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
 				"cached-path-relative": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.0.tgz",
 				"concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
@@ -2635,6 +2641,7 @@
 				"detective": "https://registry.npmjs.org/detective/-/detective-4.3.2.tgz",
 				"duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
 				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.0.tgz",
 				"parents": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
 				"readable-stream": "2.2.9",
 				"resolve": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz",
@@ -3195,17 +3202,16 @@
 				"hirestime": "3.1.1",
 				"pretty-ms": "2.1.0",
 				"readable-stream": "2.2.9",
-				"tap-parser": "5.3.3"
+				"tap-parser": "5.4.0"
 			}
 		},
 		"tap-parser": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.3.3.tgz",
-			"integrity": "sha1-U+yKkPJ11v/0PxaeVqZ5UCp0EYU=",
-			"dev": true,
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
+			"integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
 			"requires": {
-				"events-to-array": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.0.2.tgz",
-				"js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+				"events-to-array": "1.1.2",
+				"js-yaml": "3.10.0",
 				"readable-stream": "2.2.9"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"localtunnel": "^1.8.2",
 		"serve-static": "^1.12.3",
 		"stream-sink": "^2.1.0",
+		"tap-parser": "^5.4.0",
 		"wd": "^1.2.0",
 		"websocket-stream": "^5.0.0"
 	},
@@ -45,7 +46,6 @@
 		"readable-stream": "^2.2.9",
 		"source-map-support": "^0.4.15",
 		"tap-min": "^1.2.1",
-		"tap-parser": "^5.3.3",
 		"tape": "^4.6.3",
 		"uglify-es": "^3.0.25"
 	},


### PR DESCRIPTION
I wanted to try out this module but I got the following error:

```
> browserify test/browser-test.js | chutney | tap-spec

module.js:491
    throw err;
    ^

Error: Cannot find module 'tap-parser'
    at Function.Module._resolveFilename (module.js:489:15)
    at Function.Module._load (module.js:439:25)
    at Module.require (module.js:517:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> ([recacted]/node_modules/chutney/index.js:8:16)
    at Module._compile (module.js:573:30)
    at Object.Module._extensions..js (module.js:584:10)
    at Module.load (module.js:507:32)
    at tryModuleLoad (module.js:470:12)
    at Function.Module._load (module.js:462:3)
```